### PR TITLE
process 'NaN' values as NULL

### DIFF
--- a/src/Types/SimpleArrayType.php
+++ b/src/Types/SimpleArrayType.php
@@ -26,8 +26,10 @@ class SimpleArrayType extends Type
                 $numbersAsStr = $row;
             }
             foreach (explode(' ', $numbersAsStr) as $potentialNumber) {
-                if ($potentialNumber !== '') {
+                if (is_numeric($potentialNumber)) {
                     array_push($result, 0 + $potentialNumber);
+                } elseif ($potentialNumber == 'NaN') {
+                    array_push($result, null);
                 }
             }
         }


### PR DESCRIPTION
also avoid warnings when $potentialNumber is a string, example:
```
> summary(M)$coefficients
               Estimate Std. Error t value Pr(>|t|)
(Intercept) -8.46153846        NaN     NaN      NaN
disk         6.00000000        NaN     NaN      NaN
mem          0.09615385        NaN     NaN      NaN
```