### PR TITLE
add 1ms delay after write to pipe

### DIFF
--- a/src/UnixPipes.php
+++ b/src/UnixPipes.php
@@ -100,5 +100,6 @@ class UnixPipes implements PipesInterface
         }
 
         fwrite($this->pipes[0], $input);
+        usleep(1000);
     }
 }


### PR DESCRIPTION
A small delay, needed on fast configurations, allow R-command to be executed.

Just a small test:
```php
<?php

use Okvpn\R\Process\RProcess;
use Okvpn\R\UnixPipes;

require DIR . '/vendor/autoload.php';

$process = new RProcess(new UnixPipes(), '/usr/bin/R');
$process->start();

print_r($process->write('head(cars)')->getAllOutput());
```
Without delay we have:
```
Array
(
[0] => options(error=expression(NULL))
)
```

With this delay we have expected result:
```
Array
(
[0] => options(error=expression(NULL))
head(cars)
speed dist
1 4 2
2 4 10
3 7 4
4 7 22
5 8 16
6 9 10
)
```

